### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ class Employee:
 class Department:
     pass
 
-
+@strawberry.type
 class Query:
     @strawberry.field
     def departments(self):


### PR DESCRIPTION
miss @strawberry.type decorator over Query class declaration
this cause "missing _type_definition atribute" error and can confuse new users