### PR TITLE
Support class-style contexts in sqlalchemy mapper, a la fastapi style.

### DIFF
--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -413,8 +413,12 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
                         return []
                     else:
                         return None
+		if isinstance(info.context, dict):
+                    loader = info.context["sqlalchemy_loader"]
+                else:
+                    loader = info.context.sqlalchemy_loader
                 related_objects = (
-                    await info.context["sqlalchemy_loader"]
+                    await loader
                     .loader_for(relationship)
                     .load(relationship_key)
                 )


### PR DESCRIPTION
https://strawberry.rocks/docs/integrations/fastapi shows two ways to implement
contexts -- dictionary style, as is currently supported in this mapper, and
class style, which is more idiomatic in fastapi and results in a "not subscritable"
error in the current mapper implementation.

I much prefer modifying the mapper to support both styles, but if this is
something you'd rather not add, I can in theory implement __getitem__
on my custom context and it'll work just fine.

Re: tests, I couldn't find any existing tests that actually test
the mapper end-to-end with a real postgres database and server.
I would be happy to write an integration test of sorts that uses
postgresql and fastapi and tests the mapper end-to-end, just let me know.