### PR TITLE
Improved hybrid_property Type Handling

### DIFF
--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -639,10 +639,19 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
                         or "return" not in descriptor.__annotations__
                     ):
                         raise HybridPropertyNotAnnotated(key)
+                    annotation = descriptor.__annotations__["return"]
+                    if isinstance(annotation, str):
+                        try:
+                            if "typing" in annotation:
+                                # Try to evaluate from existing typing imports
+                                annotation = annotation[7:]
+                            annotation = eval(annotation)
+                        except NameError:
+                            raise UnsupportedDescriptorType(key)
                     self._add_annotation(
                         type_,
                         key,
-                        descriptor.__annotations__["return"],
+                        annotation,
                         generated_field_keys,
                     )
                 else:


### PR DESCRIPTION
For unknown reasons, when using `sqlalchemy.inspect` composite return types on `hybrid_property` decorated methods are defined as strings in `__annotations__["return"]`

This PR updates the relevant block to evaluate the given strings (e.g. `"typing.Union[float, None]"`, `"typing.Optional[float]"`) and raise an appropriate error if the type cannot be handled.